### PR TITLE
fixed the extra white space below carousel

### DIFF
--- a/main_app/templates/main_app/home.html
+++ b/main_app/templates/main_app/home.html
@@ -228,7 +228,7 @@
     </div>
   </div>
 
-  <footer class="" style="background-color:rgb(21,48,78);padding-bottom:3%; padding-top:3%;margin-top: auto">
+  <footer class="" style="background-color:rgb(21,48,78);padding-bottom:3%; padding-top:3%;margin-top: 20px">
     <div class="row" style="margin:0px;">
       <div class="col l6 s12" style="margin-left:15%;">
         <h2 class="white-text"><b>Rescue</b></h2>

--- a/main_app/templates/main_app/home.html
+++ b/main_app/templates/main_app/home.html
@@ -4,7 +4,7 @@
 <html lang="en">
 
 <head>
-
+  <meta name="viewport" content="width=device-width">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
     integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css"
@@ -228,7 +228,7 @@
     </div>
   </div>
 
-  <footer class="" style="background-color:rgb(21,48,78);padding-bottom:3%; padding-top:3%;margin-top: 20px">
+  <footer class="" style="background-color:rgb(21,48,78);padding-bottom:3%; padding-top:3%;margin-top: 90px">
     <div class="row" style="margin:0px;">
       <div class="col l6 s12" style="margin-left:15%;">
         <h2 class="white-text"><b>Rescue</b></h2>


### PR DESCRIPTION
## Related Issuse or bug
  - bug: extra space below carousel in homepage.

Fixes: #103 

#### Describe the changes you've made
I've changed the dimensions of margin of footer from the carousel. This removes the extra white space caused due to 'auto' margin.

## Type of change
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA