### PR TITLE
Fixed the extra white space for the issue #103

### DIFF
--- a/main_app/templates/main_app/home.html
+++ b/main_app/templates/main_app/home.html
@@ -63,6 +63,9 @@
     .objectives {
       text-align: center;
       padding: 60px;
+      /* Added padding */
+      padding-top: 35px;
+      padding-bottom: 5px;
     }
 
     .objectives h1 {
@@ -265,7 +268,7 @@
       </p>
     </div>
 
-    <div class="jumbotron" style="background-color: white">
+    <div class="jumbotron" style="background-color: white ; padding-bottom: 10px; padding-top: 10px; margin-bottom: 5px;">
       <link href="https://fonts.googleapis.com/css2?family=Bangers&display=swap" rel="stylesheet" />
       <h3 class="display-4" style="
           color: black;

--- a/main_app/templates/main_app/home.html
+++ b/main_app/templates/main_app/home.html
@@ -320,7 +320,7 @@
         background-color: rgb(21, 48, 78);
         padding-bottom: 3%;
         padding-top: 3%;
-        margin-top: auto;
+        margin-top: 100px;
       ">
       <div class="row" style="margin: 0px">
         <div class="col l6 s12" style="margin-left: 15%">


### PR DESCRIPTION
## Related Issue or bug
  - The issue was related on fixing the extra white space  which is there below the carousel at homepage 

Fixes: #[103]

#### Describe the changes you've made
I have fixed the extra space by making proper allignment using padding and margin changes in css






## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [Y] My code follows the code style of this project.
-->
- [ Y] Bug fix (non-breaking change which fixes an issue)
- [ N] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

#### Describe if there is any unusual behaviour of your code(Write `NA` if there isn't)
NA

## Checklist:
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [Y ] My code follows the style guidelines of this project.
- [ Y] I have performed a self-review of my own code.
- [ Y] I have commented my code, particularly in hard-to-understand areas.
- [ Y] I have made corresponding changes to the documentation.
- [ Y] My changes generate no new warnings.
- [ Y] I have added tests that prove my fix is effective or that my feature works.
- [ Y] New and existing unit tests pass locally with my changes.
- [ Y] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> 
![image](https://user-images.githubusercontent.com/73423545/111828800-d66f4d80-8911-11eb-815c-cca5ab6052a3.png)

 
 
 
 
 
 
 
 
 










